### PR TITLE
It's better to use variable ssl_bin_dir to run cfssl

### DIFF
--- a/roles/ssl/tasks/main.yml
+++ b/roles/ssl/tasks/main.yml
@@ -30,7 +30,7 @@
   when: not ca.stat.exists
 
 - name: Generate CA
-  shell: cfssl gencert -initca csr-ca.json | cfssljson -bare ca
+  shell: '{{ ssl_bin_dir }}/cfssl gencert -initca csr-ca.json | {{ ssl_bin_dir }}/cfssljson -bare ca'
   args:
     chdir: '{{ ssl_dir }}'
   when: not ca.stat.exists
@@ -76,13 +76,13 @@
   with_items: '{{ ssl_clients }}'
 
 - name: Generate certificates
-  shell: cfssl gencert -ca ca.pem -ca-key ca-key.pem -config=config.json -profile=kubernetes csr-common.json | cfssljson -bare {{ ssl_name }}
+  shell: '{{ ssl_bin_dir }}/cfssl gencert -ca ca.pem -ca-key ca-key.pem -config=config.json -profile=kubernetes csr-common.json | {{ ssl_bin_dir }}/cfssljson -bare {{ ssl_name }}'
   args:
     chdir: '{{ ssl_dir }}'
   when: not ssl_ca_only
 
 - name: Generate clients certificates
-  shell: cfssl gencert -ca ca.pem -ca-key ca-key.pem -config=config.json -profile=kubernetes csr-{{ item.name }}.json | cfssljson -bare client-{{ item.name }}
+  shell: '{{ ssl_bin_dir }}/cfssl gencert -ca ca.pem -ca-key ca-key.pem -config=config.json -profile=kubernetes csr-{{ item.name }}.json | {{ ssl_bin_dir }}/cfssljson -bare client-{{ item.name }}'
   args:
     chdir: '{{ ssl_dir }}'
   when: not ssl_ca_only


### PR DESCRIPTION
The variable `ssl_bin_dir` was pre-defined before. That was a destination directory for `cfssl` binary.  So, it's better to use this variable when we run cfssl. It might me helpful if `cfssl` is not a part of `$PATH` variable.