### PR TITLE
Drop users if they already exist

### DIFF
--- a/roles/cicd/templates/deploy-k8s-community-user-db.sh
+++ b/roles/cicd/templates/deploy-k8s-community-user-db.sh
@@ -2,6 +2,17 @@
 
 set -euo pipefail
 
+# Drop users if they already exist
+function user_rm() {
+  kubectl exec "cockroachdb-${1}" -- /cockroach/cockroach user rm ${2} \
+      --host "cockroachdb-${1}.cockroachdb" \
+      --insecure
+}
+
+user_rm 0 {{ k8s_community_db_username }}
+user_rm 0 {{ k8s_github_integration_db_username }}
+
+# Create database and user with priveleges.
 function sql() {
   kubectl exec "cockroachdb-${1}" -- /cockroach/cockroach sql \
       --host "cockroachdb-${1}.cockroachdb" \
@@ -9,7 +20,6 @@ function sql() {
       -e "$(cat /dev/stdin)"
 }
 
-# Create database and user with priveleges.
 cat <<EOF | sql 0
 CREATE DATABASE IF NOT EXISTS k8s_community;
 CREATE DATABASE IF NOT EXISTS github_integration;


### PR DESCRIPTION
If we want to be able to run this playbook multiple times, we need to re-create users if they already exist (there is no such command 'create user if not exists'). 